### PR TITLE
Update CardPaymentTokenView.swift

### DIFF
--- a/PayMayaSDK/PayMayaSDK/Views/CardPaymentTokenView.swift
+++ b/PayMayaSDK/PayMayaSDK/Views/CardPaymentTokenView.swift
@@ -24,7 +24,7 @@ private struct Constants {
     static let buttonDefaultConstraint: CGFloat = -16
 }
 
-protocol CardPaymentTokenViewContract: class {
+protocol CardPaymentTokenViewContract: AnyObject {
     func initialSetup(data: CardPaymentTokenInitialData)
 }
 


### PR DESCRIPTION
Getting warning "Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead".