### PR TITLE
Update LabeledTextField.swift

### DIFF
--- a/PayMayaSDK/PayMayaSDK/Views/TextFields/LabeledTextField.swift
+++ b/PayMayaSDK/PayMayaSDK/Views/TextFields/LabeledTextField.swift
@@ -20,7 +20,7 @@
 import Foundation
 import UIKit
 
-protocol LabeledTextFieldContract: class {
+protocol LabeledTextFieldContract: AnyObject {
     func changeValidationState(_ state: ValidationState)
     func initialSetup(data: LabeledTextFieldInitData)
     func textSet(text: String)


### PR DESCRIPTION
Getting warning "Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead"