### PR TITLE
hotfix: Use fixed 'T' as time separator in date/time parser

### DIFF
--- a/PayMayaSDK/PayMayaSDK/Networking/Extensions/Data+JSON.swift
+++ b/PayMayaSDK/PayMayaSDK/Networking/Extensions/Data+JSON.swift
@@ -28,7 +28,7 @@ extension Data {
     
     private var customDateFormatter: DateFormatter {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-ddEEEEEHH:mm:ss.SSSZ"
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
         return formatter
     }
 }


### PR DESCRIPTION
ref: https://developer.apple.com/documentation/foundation/dateformatter#2528261